### PR TITLE
Added build dependency on nexus.apromore.org to pull in spex-1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,16 @@ repositories {
 	mavenCentral()
 
 	maven {
-		url = uri('https://raw.github.com/apromore/ApromoreCore_SupportLibs/master/mvn-repo/')
+		credentials {
+			username System.properties['APROMORE_DEV_USERNAME'] ?: System.env['APROMORE_DEV_USERNAME']
+			password System.properties['APROMORE_DEV_PASSWORD'] ?: System.env['APROMORE_DEV_PASSWORD']
+		}
+		url = uri('https://nexus.apromore.org/repository/apromore-proprietary-deps/')
+		metadataSources {
+			mavenPom()
+			artifact()
+		}
 	}
-
 }
 
 dependencies {


### PR DESCRIPTION
This PR removes the dependency of the ApromoreCore_SupportLibs repository in favor of nexus.apromore.org.